### PR TITLE
Fix the issue of hanging driver.

### DIFF
--- a/tfmesos/scheduler.py
+++ b/tfmesos/scheduler.py
@@ -281,7 +281,16 @@ class TFMesosScheduler(Scheduler):
         cluster_def = {}
 
         for id, task in iteritems(self.tasks):
-            cluster_def.setdefault(task.job_name, []).append(task.addr)
+            if task.job_name is 'worker':
+                cluster_def.setdefault(task.job_name, []).append(task)
+            else:
+                cluster_def.setdefault(task.job_name, []).append(task.addr)
+
+        worker_tasks = cluster_def['worker']
+        worker_addr = map(lambda x: x.addr, sorted(worker_tasks,
+                                                   key=lambda x: x.task_index))
+
+        cluster_def['worker'] = worker_addr
 
         for id, task in iteritems(self.tasks):
             response = {


### PR DESCRIPTION
* As part of https://github.com/douban/tfmesos/pull/74, a bug was introduced when spawning up workers. We would have the training job hanging forever where the workers would be unable to talk to any of its peers. Tensorflow cluster spec requires that the cluster spec for workers be ordered by the task index.

* Because we moved `tasks` to a dictionary that is no longer honored. This will fix that .