### PR TITLE
Support graceful kill in server.py

### DIFF
--- a/tfmesos/scheduler.py
+++ b/tfmesos/scheduler.py
@@ -158,12 +158,13 @@ class Task(object):
                 gpus.type = 'SCALAR'
                 gpus.scalar.value = len(gpu_uuids)
 
-        ti.command.shell = True
-        cmd = [
-            sys.executable, '-m', '%s.server' % __package__,
-            str(self.mesos_task_id), master_addr
+        ti.command.shell = False
+        ti.command.value = sys.executable
+        ti.command.arguments = [
+            '-m', '%s.server' % __package__, str(self.mesos_task_id),
+            master_addr
         ]
-        ti.command.value = ' '.join(cmd)
+
         ti.command.environment.variables = variables = []
         env = Dict()
         variables.append(env)


### PR DESCRIPTION
* Support trapping SIGTERM so that the finalizer can run when the `CommandExecutor` and docker executor exit. The executors issue a SIGTERM and a SIGKILL after 3 seconds. The use case for us is to clean training directories, so 3 seconds should be sufficient.

* If we plan to do more than that we can leverage `KillPolicy` to extend that timeout to more than 3 seconds.